### PR TITLE
Remove trailing commas

### DIFF
--- a/changeManagement/v2/swagger2.json
+++ b/changeManagement/v2/swagger2.json
@@ -184,8 +184,8 @@
                         "required": false,
                         "in": "query",
                         "name": "status",
-                        "description":  "Status of the change request and it’s a sub-state."
-                    },
+                        "description":  "Status of the change request and it's a sub-state."
+                    }
                 ],
                 "responses": {
                     "200": {
@@ -209,7 +209,7 @@
                             "$ref": "#/definitions/Error"
                         }
                     }
-                },
+                }
             },
             "post": {
                 "operationId": "controllers.operations.creatChangeRequest",
@@ -226,7 +226,7 @@
                         "in": "body", 
                         "name": "thePost_ChangeRequest", 
                         "description": "The ChangeRequest Type to be created"
-                    },
+                    }
                 ],
                 "responses": {
                     "201": {
@@ -247,8 +247,8 @@
                             "$ref": "#/definitions/Error"
                         }
                     }
-                },
-            },
+                }
+            }
         },
         "/changeRequest/{changeRequest_id}": {
             "get": {
@@ -425,7 +425,7 @@
                         "in": "query",
                         "name": "status",
                         "description":  "Status of the change request and it’s a sub-state."
-                    },
+                    }
                 ],
                 "responses": {
                     "200": {
@@ -455,7 +455,7 @@
                             "$ref": "#/definitions/Error"
                         }
                     }
-                },
+                }
             },
             "patch": {
                 "operationId": "controllers.retrieve.updateChangeRequest",
@@ -479,7 +479,7 @@
                         "in": "body", 
                         "name": "thePatch_ChangeRequest", 
                         "description": "The ChangeRequest to be updated"
-                    },
+                    }
                 ],
                 "responses": {
                     "201": {
@@ -506,7 +506,7 @@
                             "$ref": "#/definitions/Error"
                         }
                     }
-                },
+                }
             },
             "delete": {
                 "operationId": "controllers.retrieve.deleteChangeRequest",
@@ -521,7 +521,7 @@
                         "name": "changeRequest_id", 
                         "in": "path", 
                         "description": "Identifier of the changeRequest"
-                    },
+                    }
                 ],
                 "responses": {
                     "204": {
@@ -545,8 +545,8 @@
                             "$ref": "#/definitions/Error"
                         }
                     }
-                },
-            },
+                }
+            }
         },
         "/hub": {
             "post": {
@@ -624,7 +624,7 @@
                     }
                 }
             }
-        },
+        }
     },
     "definitions": {
         "Attachment": {
@@ -633,29 +633,29 @@
             "properties": {
                 "relatedPartyRef": {
                     "$ref": "#/definitions/RelatedPartyRef",
-                    "description": "Defines parties which are involved in the change request and the role they are playing. It may be the customer, operator or 3rd party.",
+                    "description": "Defines parties which are involved in the change request and the role they are playing. It may be the customer, operator or 3rd party."
                 },
                 "dateTime": {
                     "type": "string",
-                    "description": "Date and time of the attachment generated.",
+                    "description": "Date and time of the attachment generated."
                 },
                 "description": {
                     "type": "string",
-                    "description": "The description of the attachment.",
+                    "description": "The description of the attachment."
                 },
                 "href": {
                     "type": "string",
-                    "description": "Reference of the attachment.",
+                    "description": "Reference of the attachment."
                 },
                 "id": {
                     "type": "string",
-                    "description": "Identifier of the attachment.",
-                },
+                    "description": "Identifier of the attachment."
+                }
             },
             "required": [
                 "href",
                 "id"
-            ],
+            ]
         },
         "ChangeRequest": {
             "type": "object",
@@ -663,173 +663,173 @@
             "properties": {
                 "sLARef": {
                     "$ref": "#/definitions/SLARef",
-                    "description": "A component that holds details of the SLA being applied to the change request.",
+                    "description": "A component that holds details of the SLA being applied to the change request."
                 },
                 "changeRequestCharacteristic": {
                     "$ref": "#/definitions/ChangeRequestCharacteristic",
-                    "description": "Characteristics of the change request to instantiate or to modify",
+                    "description": "Characteristics of the change request to instantiate or to modify"
                 },
                 "changeRequestSpecification": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/ChangeRequestSpecification",
+                        "$ref": "#/definitions/ChangeRequestSpecification"
                     },
-                    "description": "Defines a set of attributes related to Change Request.",
+                    "description": "Defines a set of attributes related to Change Request."
                 },
                 "workLog": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/WorkLog",
+                        "$ref": "#/definitions/WorkLog"
                     },
-                    "description": "A record of the work performed on the change request during the investigation and resolution process.",
+                    "description": "A record of the work performed on the change request during the investigation and resolution process."
                 },
                 "targetEntityRef": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/TargetEntityRef",
+                        "$ref": "#/definitions/TargetEntityRef"
                     },
-                    "description": "The entity which will be changed or configured while the change request is executed.",
+                    "description": "The entity which will be changed or configured while the change request is executed."
                 },
                 "impactEntityRef": {
                     "$ref": "#/definitions/ImpactEntityRef",
-                    "description": "Defines the entities (product, service , resource,  and other related objects) which will be impacted while the change request is executed.",
+                    "description": "Defines the entities (product, service , resource,  and other related objects) which will be impacted while the change request is executed."
                 },
                 "relatedChangeRequestRef": {
                     "$ref": "#/definitions/RelatedChangeRequestRef",
-                    "description": "An existing Change Request that has some form of correlation with the given Change Request.",
+                    "description": "An existing Change Request that has some form of correlation with the given Change Request."
                 },
                 "location": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/Location",
+                        "$ref": "#/definitions/Location"
                     },
-                    "description": "The place at whcih the change request occurred.",
+                    "description": "The place at whcih the change request occurred."
                 },
                 "note": {
                     "$ref": "#/definitions/Note",
-                    "description": "Defines the additional information of the change request.",
+                    "description": "Defines the additional information of the change request."
                 },
                 "resolution": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/Resolution",
+                        "$ref": "#/definitions/Resolution"
                     },
-                    "description": "The way one or more change request has been implementation through a direct remedy or task.",
+                    "description": "The way one or more change request has been implementation through a direct remedy or task."
                 },
                 "relatedPartyRef": {
                     "$ref": "#/definitions/RelatedPartyRef",
-                    "description": "Defines parties which are involved in the change request and the role they are playing. It may be the customer, operator or 3rd party.",
+                    "description": "Defines parties which are involved in the change request and the role they are playing. It may be the customer, operator or 3rd party."
                 },
                 "attachment": {
                     "$ref": "#/definitions/Attachment",
-                    "description": "A document or other file attached to the information about a Change Request to help explain the change being implemented as part of this Change Request.",
+                    "description": "A document or other file attached to the information about a Change Request to help explain the change being implemented as part of this Change Request."
                 },
                 "incident": {
                     "$ref": "#/definitions/Incident",
-                    "description": "An Incident is a record of an event that has altered the operational state of a entity (Resource, Service or Customer's Product).",
+                    "description": "An Incident is a record of an event that has altered the operational state of a entity (Resource, Service or Customer's Product)."
                 },
                 "actualEndTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change implementation is finished actually.",
+                    "description": "Date and time when the change implementation is finished actually."
                 },
                 "actualStartTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change implementation is started actually.",
+                    "description": "Date and time when the change implementation is started actually."
                 },
                 "budget": {
                     "type": "string",
-                    "description": "The budget reserved for the change.",
+                    "description": "The budget reserved for the change."
                 },
                 "category": {
                     "type": "string",
-                    "description": "The Category of chang request",
+                    "description": "The Category of chang request"
                 },
                 "channel": {
                     "type": "string",
-                    "description": "A channel represents the way the Change Request was created",
+                    "description": "A channel represents the way the Change Request was created"
                 },
                 "completionDate": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change request is confirmed to be completed",
+                    "description": "Date and time when the change request is confirmed to be completed"
                 },
                 "currency": {
                     "type": "string",
-                    "description": "The used currency related with cost",
+                    "description": "The used currency related with cost"
                 },
                 "description": {
                     "type": "string",
-                    "description": "Description of the change request.",
+                    "description": "Description of the change request."
                 },
                 "externalId": {
                     "type": "string",
-                    "description": "ID given by the requestor to facilitate the relationship set up and searches afterwards)",
+                    "description": "ID given by the requestor to facilitate the relationship set up and searches afterwards)"
                 },
                 "href": {
                     "type": "string",
-                    "description": "Hyperlink to access a change request",
+                    "description": "Hyperlink to access a change request"
                 },
                 "id": {
                     "type": "string",
-                    "description": "Identifier of a Change Request, it is created on repository side (Change Management system).",
+                    "description": "Identifier of a Change Request, it is created on repository side (Change Management system)."
                 },
                 "impact": {
                     "type": "string",
-                    "description": "Indicates how about the impact by this change",
+                    "description": "Indicates how about the impact by this change"
                 },
                 "plannedEndTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change implementation is planned to be finished.",
+                    "description": "Date and time when the change implementation is planned to be finished."
                 },
                 "plannedStartTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change implementation is planned to be started.",
+                    "description": "Date and time when the change implementation is planned to be started."
                 },
                 "priority": {
                     "type": "string",
-                    "description": "A way that can be used by consumers to prioritize change request in Change Management system ",
+                    "description": "A way that can be used by consumers to prioritize change request in Change Management system "
                 },
                 "requestDate": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change request is raised",
+                    "description": "Date and time when the change request is raised"
                 },
                 "requestType": {
                     "type": "string",
-                    "description": "Indicates the type of the change request.",
+                    "description": "Indicates the type of the change request."
                 },
                 "risk": {
                     "type": "string",
-                    "description": "The risk to implement this change request.",
+                    "description": "The risk to implement this change request."
                 },
                 "riskMitigationPlan": {
                     "type": "string",
-                    "description": "The risk mitigation plan.",
+                    "description": "The risk mitigation plan."
                 },
                 "riskValue": {
                     "type": "string",
-                    "description": "The additional cost if the risk will happen.",
+                    "description": "The additional cost if the risk will happen."
                 },
                 "scheduledDate": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time that the schedule is made.",
+                    "description": "Date and time that the schedule is made."
                 },
                 "status": {
                     "type": "string",
-                    "description": "Status of the change request and it’s a sub-state.",
-                },
+                    "description": "Status of the change request and it’s a sub-state."
+                }
             },
             "required": [
                 "status",
                 "priority",
                 "targetEntityRef",
                 "changeRequestSpecification"
-            ],
+            ]
         },
         "ChangeRequest_Creat": {
             "type": "object",
@@ -837,165 +837,165 @@
             "properties": {
                 "sLARef": {
                     "$ref": "#/definitions/SLARef",
-                    "description": "A component that holds details of the SLA being applied to the change request.",
+                    "description": "A component that holds details of the SLA being applied to the change request."
                 },
                 "changeRequestCharacteristic": {
                     "$ref": "#/definitions/ChangeRequestCharacteristic",
-                    "description": "Characteristics of the change request to instantiate or to modify",
+                    "description": "Characteristics of the change request to instantiate or to modify"
                 },
                 "changeRequestSpecification": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/ChangeRequestSpecification",
+                        "$ref": "#/definitions/ChangeRequestSpecification"
                     },
-                    "description": "Defines a set of attributes related to Change Request.",
+                    "description": "Defines a set of attributes related to Change Request."
                 },
                 "workLog": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/WorkLog",
+                        "$ref": "#/definitions/WorkLog"
                     },
-                    "description": "A record of the work performed on the change request during the investigation and resolution process.",
+                    "description": "A record of the work performed on the change request during the investigation and resolution process."
                 },
                 "targetEntityRef": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/TargetEntityRef",
+                        "$ref": "#/definitions/TargetEntityRef"
                     },
-                    "description": "The entity which will be changed or configured while the change request is executed.",
+                    "description": "The entity which will be changed or configured while the change request is executed."
                 },
                 "impactEntityRef": {
                     "$ref": "#/definitions/ImpactEntityRef",
-                    "description": "Defines the entities (product, service , resource,  and other related objects) which will be impacted while the change request is executed.",
+                    "description": "Defines the entities (product, service , resource,  and other related objects) which will be impacted while the change request is executed."
                 },
                 "relatedChangeRequestRef": {
                     "$ref": "#/definitions/RelatedChangeRequestRef",
-                    "description": "An existing Change Request that has some form of correlation with the given Change Request.",
+                    "description": "An existing Change Request that has some form of correlation with the given Change Request."
                 },
                 "location": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/Location",
+                        "$ref": "#/definitions/Location"
                     },
-                    "description": "The place at whcih the change request occurred.",
+                    "description": "The place at whcih the change request occurred."
                 },
                 "note": {
                     "$ref": "#/definitions/Note",
-                    "description": "Defines the additional information of the change request.",
+                    "description": "Defines the additional information of the change request."
                 },
                 "resolution": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/Resolution",
+                        "$ref": "#/definitions/Resolution"
                     },
-                    "description": "The way one or more change request has been implementation through a direct remedy or task.",
+                    "description": "The way one or more change request has been implementation through a direct remedy or task."
                 },
                 "relatedPartyRef": {
                     "$ref": "#/definitions/RelatedPartyRef",
-                    "description": "Defines parties which are involved in the change request and the role they are playing. It may be the customer, operator or 3rd party.",
+                    "description": "Defines parties which are involved in the change request and the role they are playing. It may be the customer, operator or 3rd party."
                 },
                 "attachment": {
                     "$ref": "#/definitions/Attachment",
-                    "description": "A document or other file attached to the information about a Change Request to help explain the change being implemented as part of this Change Request.",
+                    "description": "A document or other file attached to the information about a Change Request to help explain the change being implemented as part of this Change Request."
                 },
                 "incident": {
                     "$ref": "#/definitions/Incident",
-                    "description": "An Incident is a record of an event that has altered the operational state of a entity (Resource, Service or Customer's Product).",
+                    "description": "An Incident is a record of an event that has altered the operational state of a entity (Resource, Service or Customer's Product)."
                 },
                 "actualEndTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change implementation is finished actually.",
+                    "description": "Date and time when the change implementation is finished actually."
                 },
                 "actualStartTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change implementation is started actually.",
+                    "description": "Date and time when the change implementation is started actually."
                 },
                 "budget": {
                     "type": "string",
-                    "description": "The budget reserved for the change.",
+                    "description": "The budget reserved for the change."
                 },
                 "category": {
                     "type": "string",
-                    "description": "The Category of chang request",
+                    "description": "The Category of chang request"
                 },
                 "channel": {
                     "type": "string",
-                    "description": "A channel represents the way the Change Request was created",
+                    "description": "A channel represents the way the Change Request was created"
                 },
                 "completionDate": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change request is confirmed to be completed",
+                    "description": "Date and time when the change request is confirmed to be completed"
                 },
                 "currency": {
                     "type": "string",
-                    "description": "The used currency related with cost",
+                    "description": "The used currency related with cost"
                 },
                 "description": {
                     "type": "string",
-                    "description": "Description of the change request.",
+                    "description": "Description of the change request."
                 },
                 "externalId": {
                     "type": "string",
-                    "description": "ID given by the requestor to facilitate the relationship set up and searches afterwards)",
+                    "description": "ID given by the requestor to facilitate the relationship set up and searches afterwards)"
                 },
                 "impact": {
                     "type": "string",
-                    "description": "Indicates how about the impact by this change",
+                    "description": "Indicates how about the impact by this change"
                 },
                 "plannedEndTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change implementation is planned to be finished.",
+                    "description": "Date and time when the change implementation is planned to be finished."
                 },
                 "plannedStartTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change implementation is planned to be started.",
+                    "description": "Date and time when the change implementation is planned to be started."
                 },
                 "priority": {
                     "type": "string",
-                    "description": "A way that can be used by consumers to prioritize change request in Change Management system ",
+                    "description": "A way that can be used by consumers to prioritize change request in Change Management system "
                 },
                 "requestDate": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change request is raised",
+                    "description": "Date and time when the change request is raised"
                 },
                 "requestType": {
                     "type": "string",
-                    "description": "Indicates the type of the change request.",
+                    "description": "Indicates the type of the change request."
                 },
                 "risk": {
                     "type": "string",
-                    "description": "The risk to implement this change request.",
+                    "description": "The risk to implement this change request."
                 },
                 "riskMitigationPlan": {
                     "type": "string",
-                    "description": "The risk mitigation plan.",
+                    "description": "The risk mitigation plan."
                 },
                 "riskValue": {
                     "type": "string",
-                    "description": "The additional cost if the risk will happen.",
+                    "description": "The additional cost if the risk will happen."
                 },
                 "scheduledDate": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time that the schedule is made.",
+                    "description": "Date and time that the schedule is made."
                 },
                 "status": {
                     "type": "string",
-                    "description": "Status of the change request and it’s a sub-state.",
-                },
+                    "description": "Status of the change request and it’s a sub-state."
+                }
             },
             "required": [
                 "status",
                 "priority",
                 "targetEntityRef",
                 "changeRequestSpecification"
-            ],
+            ]
         },
         "ChangeRequest_Update": {
             "type": "object",
@@ -1003,159 +1003,159 @@
             "properties": {
                 "sLARef": {
                     "$ref": "#/definitions/SLARef",
-                    "description": "A component that holds details of the SLA being applied to the change request.",
+                    "description": "A component that holds details of the SLA being applied to the change request."
                 },
                 "changeRequestCharacteristic": {
                     "$ref": "#/definitions/ChangeRequestCharacteristic",
-                    "description": "Characteristics of the change request to instantiate or to modify",
+                    "description": "Characteristics of the change request to instantiate or to modify"
                 },
                 "changeRequestSpecification": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/ChangeRequestSpecification",
+                        "$ref": "#/definitions/ChangeRequestSpecification"
                     },
-                    "description": "Defines a set of attributes related to Change Request.",
+                    "description": "Defines a set of attributes related to Change Request."
                 },
                 "workLog": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/WorkLog",
+                        "$ref": "#/definitions/WorkLog"
                     },
-                    "description": "A record of the work performed on the change request during the investigation and resolution process.",
+                    "description": "A record of the work performed on the change request during the investigation and resolution process."
                 },
                 "targetEntityRef": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/TargetEntityRef",
+                        "$ref": "#/definitions/TargetEntityRef"
                     },
-                    "description": "The entity which will be changed or configured while the change request is executed.",
+                    "description": "The entity which will be changed or configured while the change request is executed."
                 },
                 "impactEntityRef": {
                     "$ref": "#/definitions/ImpactEntityRef",
-                    "description": "Defines the entities (product, service , resource,  and other related objects) which will be impacted while the change request is executed.",
+                    "description": "Defines the entities (product, service , resource,  and other related objects) which will be impacted while the change request is executed."
                 },
                 "relatedChangeRequestRef": {
                     "$ref": "#/definitions/RelatedChangeRequestRef",
-                    "description": "An existing Change Request that has some form of correlation with the given Change Request.",
+                    "description": "An existing Change Request that has some form of correlation with the given Change Request."
                 },
                 "location": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/Location",
+                        "$ref": "#/definitions/Location"
                     },
-                    "description": "The place at whcih the change request occurred.",
+                    "description": "The place at whcih the change request occurred."
                 },
                 "note": {
                     "$ref": "#/definitions/Note",
-                    "description": "Defines the additional information of the change request.",
+                    "description": "Defines the additional information of the change request."
                 },
                 "resolution": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/Resolution",
+                        "$ref": "#/definitions/Resolution"
                     },
-                    "description": "The way one or more change request has been implementation through a direct remedy or task.",
+                    "description": "The way one or more change request has been implementation through a direct remedy or task."
                 },
                 "relatedPartyRef": {
                     "$ref": "#/definitions/RelatedPartyRef",
-                    "description": "Defines parties which are involved in the change request and the role they are playing. It may be the customer, operator or 3rd party.",
+                    "description": "Defines parties which are involved in the change request and the role they are playing. It may be the customer, operator or 3rd party."
                 },
                 "attachment": {
                     "$ref": "#/definitions/Attachment",
-                    "description": "A document or other file attached to the information about a Change Request to help explain the change being implemented as part of this Change Request.",
+                    "description": "A document or other file attached to the information about a Change Request to help explain the change being implemented as part of this Change Request."
                 },
                 "incident": {
                     "$ref": "#/definitions/Incident",
-                    "description": "An Incident is a record of an event that has altered the operational state of a entity (Resource, Service or Customer's Product).",
+                    "description": "An Incident is a record of an event that has altered the operational state of a entity (Resource, Service or Customer's Product)."
                 },
                 "actualEndTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change implementation is finished actually.",
+                    "description": "Date and time when the change implementation is finished actually."
                 },
                 "actualStartTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change implementation is started actually.",
+                    "description": "Date and time when the change implementation is started actually."
                 },
                 "budget": {
                     "type": "string",
-                    "description": "The budget reserved for the change.",
+                    "description": "The budget reserved for the change."
                 },
                 "category": {
                     "type": "string",
-                    "description": "The Category of chang request",
+                    "description": "The Category of chang request"
                 },
                 "channel": {
                     "type": "string",
-                    "description": "A channel represents the way the Change Request was created",
+                    "description": "A channel represents the way the Change Request was created"
                 },
                 "completionDate": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change request is confirmed to be completed",
+                    "description": "Date and time when the change request is confirmed to be completed"
                 },
                 "currency": {
                     "type": "string",
-                    "description": "The used currency related with cost",
+                    "description": "The used currency related with cost"
                 },
                 "description": {
                     "type": "string",
-                    "description": "Description of the change request.",
+                    "description": "Description of the change request."
                 },
                 "externalId": {
                     "type": "string",
-                    "description": "ID given by the requestor to facilitate the relationship set up and searches afterwards)",
+                    "description": "ID given by the requestor to facilitate the relationship set up and searches afterwards)"
                 },
                 "impact": {
                     "type": "string",
-                    "description": "Indicates how about the impact by this change",
+                    "description": "Indicates how about the impact by this change"
                 },
                 "plannedEndTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change implementation is planned to be finished.",
+                    "description": "Date and time when the change implementation is planned to be finished."
                 },
                 "plannedStartTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change implementation is planned to be started.",
+                    "description": "Date and time when the change implementation is planned to be started."
                 },
                 "priority": {
                     "type": "string",
-                    "description": "A way that can be used by consumers to prioritize change request in Change Management system ",
+                    "description": "A way that can be used by consumers to prioritize change request in Change Management system "
                 },
                 "requestDate": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the change request is raised",
+                    "description": "Date and time when the change request is raised"
                 },
                 "requestType": {
                     "type": "string",
-                    "description": "Indicates the type of the change request.",
+                    "description": "Indicates the type of the change request."
                 },
                 "risk": {
                     "type": "string",
-                    "description": "The risk to implement this change request.",
+                    "description": "The risk to implement this change request."
                 },
                 "riskMitigationPlan": {
                     "type": "string",
-                    "description": "The risk mitigation plan.",
+                    "description": "The risk mitigation plan."
                 },
                 "riskValue": {
                     "type": "string",
-                    "description": "The additional cost if the risk will happen.",
+                    "description": "The additional cost if the risk will happen."
                 },
                 "scheduledDate": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time that the schedule is made.",
+                    "description": "Date and time that the schedule is made."
                 },
                 "status": {
                     "type": "string",
-                    "description": "Status of the change request and it’s a sub-state.",
-                },
-            },
+                    "description": "Status of the change request and it’s a sub-state."
+                }
+            }
         },
         "ChangeRequestCharacteristic": {
             "type": "object",
@@ -1163,17 +1163,17 @@
             "properties": {
                 "name": {
                     "type": "string",
-                    "description": "Name of the characteristic.",
+                    "description": "Name of the characteristic."
                 },
                 "value": {
                     "type": "string",
-                    "description": "Value of the characteristic.",
-                },
+                    "description": "Value of the characteristic."
+                }
             },
             "required": [
                 "name",
                 "value"
-            ],
+            ]
         },
         "ChangeRequestSpecification": {
             "type": "object",
@@ -1182,31 +1182,31 @@
                 "validFor": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/ValidFor",
+                        "$ref": "#/definitions/ValidFor"
                     },
-                    "description": "A valid duration of a thing.",
+                    "description": "A valid duration of a thing."
                 },
                 "description": {
                     "type": "string",
-                    "description": "Description of the specification",
+                    "description": "Description of the specification"
                 },
                 "href": {
                     "type": "string",
-                    "description": "Hyperlink to access the specification.",
+                    "description": "Hyperlink to access the specification."
                 },
                 "id": {
                     "type": "string",
-                    "description": "Identifier of the specification.",
+                    "description": "Identifier of the specification."
                 },
                 "name": {
                     "type": "string",
-                    "description": "Name of the specification.",
-                },
+                    "description": "Name of the specification."
+                }
             },
             "required": [
                 "href",
                 "id"
-            ],
+            ]
         },
         "ImpactEntityRef": {
             "type": "object",
@@ -1214,21 +1214,21 @@
             "properties": {
                 "description": {
                     "type": "string",
-                    "description": "a description and analysis of the impact of the change request on the Product, Service or Resource.",
+                    "description": "a description and analysis of the impact of the change request on the Product, Service or Resource."
                 },
                 "href": {
                     "type": "string",
-                    "description": "Hyperlink to access the impacted party, it could be a party reference or a party role reference.",
+                    "description": "Hyperlink to access the impacted party, it could be a party reference or a party role reference."
                 },
                 "id": {
                     "type": "string",
-                    "description": "Identifier of impacted entity.",
-                },
+                    "description": "Identifier of impacted entity."
+                }
             },
             "required": [
                 "href",
                 "id"
-            ],
+            ]
         },
         "Incident": {
             "type": "object",
@@ -1236,17 +1236,17 @@
             "properties": {
                 "impactEntityRef": {
                     "$ref": "#/definitions/ImpactEntityRef",
-                    "description": "Defines the entities (product, service , resource,  and other related objects) which will be impacted while the change request is executed.",
+                    "description": "Defines the entities (product, service , resource,  and other related objects) which will be impacted while the change request is executed."
                 },
                 "description": {
                     "type": "string",
-                    "description": "The description of the incident.",
+                    "description": "The description of the incident."
                 },
                 "name": {
                     "type": "string",
-                    "description": "The name of the incident.",
-                },
-            },
+                    "description": "The name of the incident."
+                }
+            }
         },
         "Location": {
             "type": "object",
@@ -1254,13 +1254,13 @@
             "properties": {
                 "address": {
                     "type": "string",
-                    "description": "The detail address of the location.",
+                    "description": "The detail address of the location."
                 },
                 "postCode": {
                     "type": "string",
-                    "description": "The post code of an address.",
-                },
-            },
+                    "description": "The post code of an address."
+                }
+            }
         },
         "Note": {
             "type": "object",
@@ -1268,18 +1268,18 @@
             "properties": {
                 "author": {
                     "type": "string",
-                    "description": "Indicates who provides the description.",
+                    "description": "Indicates who provides the description."
                 },
                 "dateTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the description was inputted. ",
+                    "description": "Date and time when the description was inputted. "
                 },
                 "text": {
                     "type": "string",
-                    "description": "The additional description.",
-                },
-            },
+                    "description": "The additional description."
+                }
+            }
         },
         "Record": {
             "type": "object",
@@ -1287,20 +1287,20 @@
             "properties": {
                 "dateTime": {
                     "type": "string",
-                    "description": "The date time that a record is generated.",
+                    "description": "The date time that a record is generated."
                 },
                 "description": {
                     "type": "string",
-                    "description": "The detail description in a record.",
+                    "description": "The detail description in a record."
                 },
                 "supportPerson": {
                     "type": "string",
-                    "description": "The person who logged that record.",
-                },
+                    "description": "The person who logged that record."
+                }
             },
             "required": [
                 "dateTime"
-            ],
+            ]
         },
         "RelatedChangeRequestRef": {
             "type": "object",
@@ -1308,25 +1308,25 @@
             "properties": {
                 "correlation": {
                     "type": "string",
-                    "description": "The correlation between two change requests",
+                    "description": "The correlation between two change requests"
                 },
                 "description": {
                     "type": "string",
-                    "description": "Description of a change request.",
+                    "description": "Description of a change request."
                 },
                 "href": {
                     "type": "string",
-                    "description": "Hyper link to access a change request.",
+                    "description": "Hyper link to access a change request."
                 },
                 "id": {
                     "type": "string",
-                    "description": "Identifier of an Change Request",
-                },
+                    "description": "Identifier of an Change Request"
+                }
             },
             "required": [
                 "id",
                 "href"
-            ],
+            ]
         },
         "RelatedPartyRef": {
             "type": "object",
@@ -1334,29 +1334,29 @@
             "properties": {
                 "contactInfo": {
                     "type": "string",
-                    "description": "Contact information of the party.",
+                    "description": "Contact information of the party."
                 },
                 "href": {
                     "type": "string",
-                    "description": "Hyperlink to access a related party.",
+                    "description": "Hyperlink to access a related party."
                 },
                 "id": {
                     "type": "string",
-                    "description": "Identifier of a related party.",
+                    "description": "Identifier of a related party."
                 },
                 "name": {
                     "type": "string",
-                    "description": "Name of related party.",
+                    "description": "Name of related party."
                 },
                 "role": {
                     "type": "string",
-                    "description": "Role of related Party.",
-                },
+                    "description": "Role of related Party."
+                }
             },
             "required": [
                 "href",
                  "id"
-            ],
+            ]
         },
         "Resolution": {
             "type": "object",
@@ -1364,25 +1364,25 @@
             "properties": {
                 "task": {
                     "$ref": "#/definitions/Task",
-                    "description": "A step or task along in the process of  implementation a Change Request.",
+                    "description": "A step or task along in the process of  implementation a Change Request."
                 },
                 "code": {
                     "type": "string",
-                    "description": "The resolution's code, it can be configured as a multiple level hierarchy.",
+                    "description": "The resolution's code, it can be configured as a multiple level hierarchy."
                 },
                 "description": {
                     "type": "string",
-                    "description": "The description of the resolution.",
+                    "description": "The description of the resolution."
                 },
                 "name": {
                     "type": "string",
-                    "description": "The name of the resoultion",
-                },
+                    "description": "The name of the resoultion"
+                }
             },
             "required": [
                 "name",
                 "description"
-            ],
+            ]
         },
         "SLARef": {
             "type": "object",
@@ -1390,25 +1390,25 @@
             "properties": {
                 "description": {
                     "type": "string",
-                    "description": "Description of a SLA",
+                    "description": "Description of a SLA"
                 },
                 "href": {
                     "type": "string",
-                    "description": "Hyper link to a SLA",
+                    "description": "Hyper link to a SLA"
                 },
                 "id": {
                     "type": "string",
-                    "description": "Identifier of a SLA",
+                    "description": "Identifier of a SLA"
                 },
                 "name": {
                     "type": "string",
-                    "description": "The name of a SLA",
-                },
+                    "description": "The name of a SLA"
+                }
             },
             "required": [
                 "id",
                 "href"
-            ],
+            ]
         },
         "TargetEntityRef": {
             "type": "object",
@@ -1416,21 +1416,21 @@
             "properties": {
                 "description": {
                     "type": "string",
-                    "description": "The description to the related party.",
+                    "description": "The description to the related party."
                 },
                 "href": {
                     "type": "string",
-                    "description": "Hyperlink to access the target entity.",
+                    "description": "Hyperlink to access the target entity."
                 },
                 "id": {
                     "type": "string",
-                    "description": "Identifier of target entity",
-                },
+                    "description": "Identifier of target entity"
+                }
             },
             "required": [
                 "href",
                 "id"
-            ],
+            ]
         },
         "Task": {
             "type": "object",
@@ -1438,17 +1438,17 @@
             "properties": {
                 "description": {
                     "type": "string",
-                    "description": "The description of the task.",
+                    "description": "The description of the task."
                 },
                 "name": {
                     "type": "string",
-                    "description": "The name of the task.",
+                    "description": "The name of the task."
                 },
                 "state": {
                     "type": "string",
-                    "description": "The state of the task.",
-                },
-            },
+                    "description": "The state of the task."
+                }
+            }
         },
         "ValidFor": {
             "type": "object",
@@ -1457,18 +1457,18 @@
                 "endDateTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "The end date and time.",
+                    "description": "The end date and time."
                 },
                 "startDateTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "The start date and time.",
-                },
+                    "description": "The start date and time."
+                }
             },
             "required": [
                 "startDateTime",
                 "endDateTime"
-            ],
+            ]
         },
         "WorkLog": {
             "type": "object",
@@ -1476,26 +1476,26 @@
             "properties": {
                 "record": {
                     "$ref": "#/definitions/Record",
-                    "description": "A record in a worklog.",
+                    "description": "A record in a worklog."
                 },
                 "creatDateTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time of worklog generated.",
+                    "description": "Date and time of worklog generated."
                 },
                 "description": {
                     "type": "string",
-                    "description": "The description of the worklog.",
+                    "description": "The description of the worklog."
                 },
                 "lastUpdateDateTime": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Date and time when the worklog updated.",
-                },
+                    "description": "Date and time when the worklog updated."
+                }
             },
             "required": [
                 "creatDateTime"
-            ],
+            ]
         },
         "EventSubscription": {
             "required": [
@@ -1555,6 +1555,6 @@
                     "description": "(optional) A URL to online documentation that provides more information about the error."
                 }
             }
-        },
+        }
     }
 }


### PR DESCRIPTION
Trailing commas are invalid in JSON and cause parsers like Python's
json.loads() to fail.

This patch removes all of the commas after the last entry in a list or the last property in an object.